### PR TITLE
Make changes to fix collapsible to make the read more not show when u…

### DIFF
--- a/QRCodeTarot.xcodeproj/project.pbxproj
+++ b/QRCodeTarot.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		75194FD8284A5C8F0060175C /* Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75194FD7284A5C8F0060175C /* Cards.swift */; };
 		75194FDA284A5CA30060175C /* Suit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75194FD9284A5CA30060175C /* Suit.swift */; };
 		75194FDC284A5CB90060175C /* Importance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75194FDB284A5CB90060175C /* Importance.swift */; };
+		75194FE0284AF1C30060175C /* CollapsibleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75194FDF284AF1C30060175C /* CollapsibleViewModelTests.swift */; };
 		7526AFEC27FA70B0009C5FE8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7526AFEB27FA70B0009C5FE8 /* AppDelegate.swift */; };
 		7526AFEE27FA70B0009C5FE8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7526AFED27FA70B0009C5FE8 /* SceneDelegate.swift */; };
 		7526AFF027FA70B0009C5FE8 /* QrReaderViewcontroller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7526AFEF27FA70B0009C5FE8 /* QrReaderViewcontroller.swift */; };
@@ -139,6 +140,7 @@
 		75194FD7284A5C8F0060175C /* Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cards.swift; sourceTree = "<group>"; };
 		75194FD9284A5CA30060175C /* Suit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Suit.swift; sourceTree = "<group>"; };
 		75194FDB284A5CB90060175C /* Importance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Importance.swift; sourceTree = "<group>"; };
+		75194FDF284AF1C30060175C /* CollapsibleViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleViewModelTests.swift; sourceTree = "<group>"; };
 		7526AFE827FA70B0009C5FE8 /* QRCodeTarot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QRCodeTarot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7526AFEB27FA70B0009C5FE8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7526AFED27FA70B0009C5FE8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 				75D0914127FBDBA80037798C /* LocalCardsTests.swift */,
 				757A80D32822620F00700990 /* LocalImageTests.swift */,
 				756A68CF27FD484C00B76CCD /* QRViewControllerTests.swift */,
+				75194FDF284AF1C30060175C /* CollapsibleViewModelTests.swift */,
 			);
 			path = QRCodeTarotTests;
 			sourceTree = "<group>";
@@ -921,6 +924,7 @@
 				757A80D42822620F00700990 /* LocalImageTests.swift in Sources */,
 				75D0914227FBDBA80037798C /* LocalCardsTests.swift in Sources */,
 				756A68D027FD484C00B76CCD /* QRViewControllerTests.swift in Sources */,
+				75194FE0284AF1C30060175C /* CollapsibleViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/QRCodeTarot/ImageContainer/CollapsableLabelLabel.ViewModel.swift
+++ b/QRCodeTarot/ImageContainer/CollapsableLabelLabel.ViewModel.swift
@@ -7,24 +7,47 @@
 
 import Foundation
 import TableMVVM
+import CommonExtensions
 
 extension CollapsableLabelLabel {
 
     struct ViewModel: HasFallBack {
         var labelLabelViewModel: LabelLabel.ViewModel
         var buttonText: String = "Read More"
+
         var buttonIsHidden: Bool = false
         var buttonTapped: Action? 
 
         init(
+            topText: String = "Description",
+            bottomText: String,
+            buttonText: String = "Read More",
+            lineCutoff: Int = 4,
+            actualLineCount: Int
+        ) {
+            self.init(
+                topText: topText,
+                bottomText: bottomText,
+                lineCount: actualLineCount > lineCutoff ? lineCutoff : 0,
+                buttonText: buttonText,
+                buttonIsHidden: actualLineCount < (lineCutoff + 1)
+            )
+        }
+
+        init(
             topText: String,
             bottomText: String,
-            startLineCount: Int = 4,
-            buttonText: String = "Read More"
+            lineCount: Int = 5,
+            buttonText: String = "Read More",
+            buttonIsHidden: Bool = false
         ) {
-            self.labelLabelViewModel = .init(topText: topText, bottomText: bottomText, lineCount: startLineCount)
+            self.labelLabelViewModel = .init(
+                topText: topText,
+                bottomText: bottomText,
+                lineCount: lineCount
+            )
             self.buttonText = buttonText
-            buttonIsHidden = false
+            self.buttonIsHidden = buttonIsHidden
         }
 
         static var fallBack: CollapsableLabelLabel.ViewModel {

--- a/QRCodeTarot/ImageContainer/CollapsableLabelLabel.swift
+++ b/QRCodeTarot/ImageContainer/CollapsableLabelLabel.swift
@@ -27,6 +27,8 @@ class CollapsableLabelLabel: NibView, HasViewModel {
     var viewModel: ViewModel = .fallBack {
         didSet {
             labelLabel.viewModel = viewModel.labelLabelViewModel
+            labelLabel.bottomLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+            labelLabel.bottomLabel.setContentHuggingPriority(.required, for: .vertical)
 
             button.setTitle(viewModel.buttonText, for: .normal)
             button.layer.cornerRadius = 12

--- a/QRCodeTarot/ViewControllers/CardDetailViewController/CardDetailViewController.swift
+++ b/QRCodeTarot/ViewControllers/CardDetailViewController/CardDetailViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import TableMVVM
+import CommonExtensions
 
 typealias CardImageCell = ViewModelCell<CardImageView>
 typealias CollapseTextCell = ViewModelCell<CollapsableLabelLabel>
@@ -50,7 +51,11 @@ class CardDetailViewController: UIViewController {
             section2: SectionOneRow(
                 cellViewModel: CollapsableLabelLabel.ViewModel(
                     topText: "Description",
-                    bottomText: card.desc
+                    bottomText: card.desc,
+                    lineCutoff: 4,
+                    actualLineCount: UILabel.zero
+                        .with(text: card.desc)
+                        .lineCount(withWidth: detailController.view.frame.width.int)
                 )
             ),
             section3: SectionOneRow(cellViewModel: TarotSwitchView.ViewModel()),

--- a/QRCodeTarot/ViewControllers/DetailsViewController/DetailsViewController.swift
+++ b/QRCodeTarot/ViewControllers/DetailsViewController/DetailsViewController.swift
@@ -49,5 +49,7 @@ class DetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.inject(view: tableView)
+      //  tableView.contentInset = .init(top: 0, left: 24, bottom: 0, right: -24) // right side seems to have no effect.
+      //  tableView.contentInsetAdjustmentBehavior = .never
     }
 }

--- a/QRCodeTarotTests/CollapsibleViewModelTests.swift
+++ b/QRCodeTarotTests/CollapsibleViewModelTests.swift
@@ -1,0 +1,43 @@
+//
+//  CollapsibleViewModelTests.swift
+//  QRCodeTarotTests
+//
+//  Created by Scott Lydon on 6/3/22.
+//
+
+import XCTest
+import QRCodeReader
+@testable import QRCodeTarot
+
+class CollapsibleViewModelTests: XCTestCase {
+
+    func testCollapsableLabelLabelViewModel() {
+        let viewModel: CollapsableLabelLabel.ViewModel = .init(
+            bottomText: "asdflkjlkj lkj lkj lkj lkaj sdlfkj lakjsd flkajs dflkja sldkjf alskdjf laksjdf laksjd flkj    asdflkj asdlfkj alskdjf asldkfj alksjd flkja sldkfja lskdjf alksjdf lkajsd flkja sldkfj",
+            lineCutoff: 4,
+            actualLineCount: 20
+        )
+        XCTAssertFalse(viewModel.buttonIsHidden)
+        XCTAssertEqual(viewModel.labelLabelViewModel.lineCount, 4)
+    }
+
+    func testCollapsableLabelLabelViewModel2() {
+        let viewModel: CollapsableLabelLabel.ViewModel = .init(
+            bottomText: "asdflkjlkj lkj lkj lkj lkaj sdlfkj lakjsd flkajs dflkja sldkjf alskdjf laksjdf laksjd flkj    asdflkj asdlfkj alskdjf asldkfj alksjd flkja sldkfja lskdjf alksjdf lkajsd flkja sldkfj",
+            lineCutoff: 4,
+            actualLineCount: 1
+        )
+        XCTAssertTrue(viewModel.buttonIsHidden)
+        XCTAssertEqual(viewModel.labelLabelViewModel.lineCount, 0)
+    }
+
+    func testCollapsableLabelLabelViewModel3() {
+        let viewModel: CollapsableLabelLabel.ViewModel = .init(
+            bottomText: "asdflkjlkj lkj lkj lkj lkaj sdlfkj lakjsd flkajs dflkja sldkjf alskdjf laksjdf laksjd flkj    asdflkj asdlfkj alskdjf asldkfj alksjd flkja sldkfja lskdjf alksjdf lkajsd flkja sldkfj",
+            lineCutoff: 4,
+            actualLineCount: 4
+        )
+        XCTAssertTrue(viewModel.buttonIsHidden)
+        XCTAssertEqual(viewModel.labelLabelViewModel.lineCount, 0)
+    }
+}


### PR DESCRIPTION
All that I am doing is 
- Adding logic to the view model so that I can hide the collapse button properly given the amount of text.  However, it appears, 
However, for some reason, it is causing a regression where the buttonTapped becomes nil somehow...It puts into question this whole MVVM setup.  

Maybe if I remove the convenience initializer?...

Regression: 
- Text does not unfurl, after tapping read more.  When I click on the 1 of cups, there should be a lot of text that unfurls, however, it is limited by the cell size because the buttonTapped action is no longer called, because it is somehow set to nil, or bypassed altogether.  It is difficult to debug, because it is set this way in the cellforrowat method in TableMVVM, which doesn't retain type information.  This is a downside of using generics.  If at the point that the generic there is a bug it is difficult to get type information to get value information.  I think maybe you can just print the value without having to convert it.  

Another peripheral regression: 
- cell height does not adjust after read more tapped instead, the text content adjusts to the cell height...I have no offing idea how just changing the model can do that. 